### PR TITLE
fix: logging for incomplete request response

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -76,6 +76,7 @@ struct AppLayerThreadCtx_ {
 typedef struct AppLayerCounterNames_ {
     char name[MAX_COUNTER_SIZE];
     char tx_name[MAX_COUNTER_SIZE];
+    char tx_incomplete_drops[MAX_COUNTER_SIZE];
     char gap_error[MAX_COUNTER_SIZE];
     char parser_error[MAX_COUNTER_SIZE];
     char internal_error[MAX_COUNTER_SIZE];
@@ -85,6 +86,7 @@ typedef struct AppLayerCounterNames_ {
 typedef struct AppLayerCounters_ {
     uint16_t counter_id;
     uint16_t counter_tx_id;
+    uint16_t counter_tx_incomplete_id;
     uint16_t gap_error_id;
     uint16_t parser_error_id;
     uint16_t internal_error_id;
@@ -124,6 +126,14 @@ void AppLayerIncTxCounter(ThreadVars *tv, Flow *f, uint64_t step)
     const uint16_t id = applayer_counters[f->protomap][f->alproto].counter_tx_id;
     if (likely(tv && id > 0)) {
         StatsAddUI64(tv, id, step);
+    }
+}
+
+void AppLayerIncTxDropCounter(ThreadVars *tv, Flow *f)
+{
+    const uint16_t id = applayer_counters[f->protomap][f->alproto].counter_tx_incomplete_id;
+    if (likely(tv && id > 0)) {
+        StatsIncr(tv, id);
     }
 }
 
@@ -1102,6 +1112,9 @@ void AppLayerSetupCounters()
                     snprintf(applayer_counter_names[ipproto_map][alproto].tx_name,
                             sizeof(applayer_counter_names[ipproto_map][alproto].tx_name),
                             "%s%s", tx_str, alproto_str);
+                    snprintf(applayer_counter_names[ipproto_map][alproto].tx_incomplete_drops,
+                            sizeof(applayer_counter_names[ipproto_map][alproto].tx_incomplete_drops),
+                            "%s%s.incomplete_tx_drops", tx_str, alproto_str);
 
                     if (ipproto == IPPROTO_TCP) {
                         snprintf(applayer_counter_names[ipproto_map][alproto].gap_error,
@@ -1149,6 +1162,9 @@ void AppLayerRegisterThreadCounters(ThreadVars *tv)
 
                 applayer_counters[ipproto_map][alproto].counter_tx_id =
                     StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].tx_name, tv);
+
+                applayer_counters[ipproto_map][alproto].counter_tx_incomplete_id =
+                    StatsRegisterCounter(applayer_counter_names[ipproto_map][alproto].tx_incomplete_drops, tv);
 
                 if (ipproto == IPPROTO_TCP) {
                     applayer_counters[ipproto_map][alproto].gap_error_id = StatsRegisterCounter(

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -144,6 +144,7 @@ void AppLayerUnittestsRegister(void);
 #endif
 
 void AppLayerIncTxCounter(ThreadVars *tv, Flow *f, uint64_t step);
+void AppLayerIncTxDropCounter(ThreadVars *tv, Flow *f);
 void AppLayerIncGapErrorCounter(ThreadVars *tv, Flow *f);
 void AppLayerIncAllocErrorCounter(ThreadVars *tv, Flow *f);
 void AppLayerIncParserErrorCounter(ThreadVars *tv, Flow *f);

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -484,6 +484,8 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
 
     // Log only if request and response have progressed to completion
     if (tx->request_progress != HTP_REQUEST_COMPLETE || tx->response_progress != HTP_RESPONSE_COMPLETE) {
+        SCLogDebug("got an incomplete HTTP request or response");
+        AppLayerIncTxDropCounter(tv, f);
         SCReturnInt(TM_ECODE_OK);
     }
 

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -481,6 +481,12 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     SCEnter();
 
     htp_tx_t *tx = txptr;
+
+    // Log only if request and response have progressed to completion
+    if (tx->request_progress != HTP_REQUEST_COMPLETE || tx->response_progress != HTP_RESPONSE_COMPLETE) {
+        SCReturnInt(TM_ECODE_OK);
+    }
+
     JsonHttpLogThread *jhl = (JsonHttpLogThread *)thread_data;
 
     JsonBuilder *js = CreateEveHeaderWithTxId(
@@ -491,6 +497,7 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     SCLogDebug("got a HTTP request and now logging !!");
 
     EveHttpLogJSON(jhl, js, tx, tx_id);
+
     HttpXFFCfg *xff_cfg = jhl->httplog_ctx->xff_cfg != NULL ?
         jhl->httplog_ctx->xff_cfg : jhl->httplog_ctx->parent_xff_cfg;
 

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -495,8 +495,8 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
         return TM_ECODE_OK;
 
     SCLogDebug("got a HTTP request and now logging !!");
-    EveHttpLogJSON(jhl, js, tx, tx_id);
 
+    EveHttpLogJSON(jhl, js, tx, tx_id);
     HttpXFFCfg *xff_cfg = jhl->httplog_ctx->xff_cfg != NULL ?
         jhl->httplog_ctx->xff_cfg : jhl->httplog_ctx->parent_xff_cfg;
 

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -495,7 +495,6 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
         return TM_ECODE_OK;
 
     SCLogDebug("got a HTTP request and now logging !!");
-
     EveHttpLogJSON(jhl, js, tx, tx_id);
 
     HttpXFFCfg *xff_cfg = jhl->httplog_ctx->xff_cfg != NULL ?


### PR DESCRIPTION
### Context

https://traceableai.atlassian.net/browse/ENG-28013

### Reproduction Steps

#### Method 1

* Using 3 EC2 machines, a client EC2, a server EC2 and EC2 machine where the server traffic was being mirrored.
* On Client EC2, install wrk, a load generation tool to do a stress test on the server EC2.
* On Server EC2, deploy a custom node HTTP echo server.
* On Mirror EC2, run suricata in file writing mode where it doesn't transmit data to TPA but instead writes the constructed HTTP request/response to a json file.
* Do a heavy load test on the server so that there are packet losses.
* Observe the json file for a HTTP request/response where request is truncated.

#### Method 2

This was the genius of @t-santoshsahu where he thought of emulating packet loss by manually deleting a tcp packet underlying an HTTP request.

* Capture network traffic on port 80 using tcpdump: `tcpdump -i en0 port 80 -w capture.pcap`
* Send a big request to `httpbin.org` or any other echo server: `curl httpbin.org/post httpbin.org/post --header 'Content-Type: application/json' -d '{"type": "note", "title": "'"$A$A$A"'"}'`
* In this case, environment variable A was set a really big string of `a's`.
* Make sure the `capture.pcap` file has the request divided into multiple TCP packets.
* Delete the last packet of the TCP request packets and export the remaining packets to another file, say, `capture-edited.pcap`
* Change the suricata config file to log to a file instead of the unix socket. Change `file-type` under `eve-log` to `regular` instead of `unix_dgram`
* Replay the edited `capture-edited.pcap` into suricata: `/usr/bin/suricata -c /var/log/suricata/suricata.yaml -r capture-edited.pcap`

### Change Description

Change logging of suricata to log only when the HTTP Transaction's request and response have progressed to completed state. Since this was not being checked before, suricata was also logging HTTP Transactions in states other than completed.

In addition also add a counter and increment the counter whenever we drop the transaction for being incomplete.

### Testing

All of the following tests were done manually which hopefully we can automate some day.

#### Test 1: Delete the last packet in the HTTP Request TCP stream and run suricata

Suricata does not log the transaction.
Result: OK

#### Test 2: Delete the first packet in the HTTP Request TCP stream and run suricata

Suricata mixes up multiple streams and generates malformed HTTP transaction and it's request/response.
Result: FAIL (Unrelated to this PR since this was already happening and is not a regression).

#### Test 3: Delete all packets in the HTTP Request TCP stream and run suricata

Suricata logs an HTTP transaction with a malformed URI and the request body is not logged.
Result: FAIL (Unrelated to this PR since this was already happening and is not a regression).

#### Test 4: Delete the last packet in the HTTP Response TCP stream and run suricata

Suricata logs an HTTP transaction with malformed URI, malformed response body and no request body
Result: FAIL

#### Test 5: Delete the first packet in the HTTP Response TCP stream and run suricata

Suricata logs an HTTP transaction with malformed URI, malformed response body and no request body
Result: FAIL

#### Test 6: Delete all packets in the HTTP Response TCP stream and run suricata

Suricata logs an HTTP transaction with malformed URI and no request body
Result: FAIL

#### stats.log file after adding the counter

<img width="1070" alt="Screenshot 2023-03-09 at 7 01 22 PM" src="https://user-images.githubusercontent.com/75965317/224188721-17129fce-b740-4d46-bad6-883a66b039b0.png">
