### PR TITLE
fix: integer overflow

### DIFF
--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -247,10 +247,10 @@ enum TcpState {
 /* Macro's for comparing Sequence numbers
  * Page 810 from TCP/IP Illustrated, Volume 2. */
 #define SEQ_EQ(a,b)  ((int32_t)((a) - (b)) == 0)
-#define SEQ_LT(a,b)  ((int32_t)((a) - (b)) <  0)
-#define SEQ_LEQ(a,b) ((int32_t)((a) - (b)) <= 0)
-#define SEQ_GT(a,b)  ((int32_t)((a) - (b)) >  0)
-#define SEQ_GEQ(a,b) ((int32_t)((a) - (b)) >= 0)
+#define SEQ_LT(a,b)  (((a) < (b)) && ((int32_t)((a) - (b)) < 0))
+#define SEQ_LEQ(a,b) (((a) <= (b)) && ((int32_t)((a) - (b)) <= 0))
+#define SEQ_GT(a,b)  (((a) > (b)) && ((int32_t)((a) - (b)) > 0))
+#define SEQ_GEQ(a,b) (((a) >= (b)) && ((int32_t)((a) - (b)) >= 0))
 
 #define STREAMTCP_SET_RA_BASE_SEQ(stream, seq) { \
     do { \


### PR DESCRIPTION
Large sequence numbers cause a bug which leads suricata to stop processing the flow/connection

The following program (Try it out here: https://www.programiz.com/c-programming/online-compiler/)

```C
#include <stdio.h>
#include <stdint.h>

#define SEQ_LEQ(a, b) (((a) <= (b)) && ((int32_t)((a) - (b)) <= 0))
#define BUGGY_SEQ_LEQ(a,b) ((int32_t)((a) - (b)) <= 0)


int main() {
    uint32_t last_ack = 354499041;
    uint32_t seq1 = 2501950844;
    uint32_t seq2 = 2503051699;

    printf("Correct SEQ_LEQ Implementation\n");
    if (SEQ_LEQ(seq1, last_ack)) {
        printf("seq1 is less than or equal to last_ack\n");
    } else {
        printf("seq1 is greater than last_ack\n");
    }
    
    if (SEQ_LEQ(seq2, last_ack)) {
        printf("seq2 is less than or equal to last_ack\n");
    } else {
        printf("seq2 is greater than last_ack\n");
    }
    
    printf("Buggy SEQ_LEQ Implementation\n");
    if (BUGGY_SEQ_LEQ(seq1, last_ack)) {
        printf("seq1 is less than or equal to last_ack\n");
    } else {
        printf("seq1 is greater than last_ack\n");
    }
    
    if (BUGGY_SEQ_LEQ(seq2, last_ack)) {
        printf("seq2 is less than or equal to last_ack\n");
    } else {
        printf("seq2 is greater than last_ack\n");
    }

    return 0;
}
```

prints

```
Correct SEQ_LEQ Implementation
seq1 is greater than last_ack
seq2 is greater than last_ack
Buggy SEQ_LEQ Implementation
seq1 is greater than last_ack
seq2 is less than or equal to last_ack
```
